### PR TITLE
Docs: Bumped PHP version as per composer.json

### DIFF
--- a/developers/setup-local-development.md
+++ b/developers/setup-local-development.md
@@ -4,7 +4,7 @@ These are the steps required to setup the local development.
 
 Monica is a Laravel application. That means it requires this setup:
 
-* PHP 8.1 or newer
+* PHP 8.2 or newer
 * HTTP server with PHP support (eg: Apache, Nginx, Caddy)
 * Composer
 * MySQL


### PR DESCRIPTION
The compose.json in the repository has a minimum requirement of 8.2, but the docs stated earlier it was 8.1. I changed it to align better with the current requirements.